### PR TITLE
Changing wrapping pulsestorm_simple node to container

### DIFF
--- a/first-pass-unstable/app/code/Pulsestorm/SimpleUiComponent/view/adminhtml/ui_component/pulsestorm_simple.xml
+++ b/first-pass-unstable/app/code/Pulsestorm/SimpleUiComponent/view/adminhtml/ui_component/pulsestorm_simple.xml
@@ -1,4 +1,4 @@
-<pulsestorm_simple xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
+<container xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
     <argument name="data" xsi:type="array">
         <item name="template" xsi:type="string">templates/different</item>
     </argument>
@@ -19,4 +19,4 @@
         </argument>        
  
     </dataSource>
-</pulsestorm_simple>
+</container>


### PR DESCRIPTION
In response to the issue raised on this repo, I found that changing the pulsestorm_simple node in the first-pass-unstable module's pulse storm_simple.xml to 'container' à la the second-pass-stable module fixed the issue and the admin page loaded fine.